### PR TITLE
Swift5.9

### DIFF
--- a/Source/Unimplemented.swift
+++ b/Source/Unimplemented.swift
@@ -7,8 +7,8 @@ func unimplementedFunction(file: String = #file, function: String = #function, l
 
 extension Observable {
     static func unimplemented(file: String = #file, function: String = #function, line: Int = #line)
-        -> Observable<Element> {
+    -> Observable<Element> {
         unimplementedFunction(file: file, function: function, line: line)
-        return Observable<Element>.empty()
+        return Observable.empty()
     }
 }


### PR DESCRIPTION
Swift5.9からエラーになる部分を修正しました

swift5.9から導入されたObservableとRxSwiftのObservableが同名なのが原因のようです。